### PR TITLE
Add archiver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 # Find out more: https://morph.io/documentation/ruby
 
 source "https://rubygems.org"
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby "2.0.0"
 
@@ -14,3 +15,4 @@ gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
+gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/everypolitician/scraped_page_archive.git
+  revision: 317f10cf3c6abbfb7f1871e80c73b8d8cf07f07a
+  specs:
+    scraped_page_archive (0.4.1)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -10,8 +18,11 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
     coderay (1.1.0)
     colorize (0.7.7)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     excon (0.45.4)
     execjs (2.5.2)
     faraday (0.9.1)
@@ -19,6 +30,8 @@ GEM
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     fuzzy_match (2.1.0)
+    git (1.3.0)
+    hashdiff (0.3.0)
     hashie (3.4.2)
     httpclient (2.6.0.1)
     method_source (0.8.2)
@@ -31,10 +44,19 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    safe_yaml (1.0.4)
     slop (3.6.0)
     sqlite3 (1.3.10)
     sqlite_magic (0.0.3)
       sqlite3
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     wikidata-client (0.0.7)
       excon (~> 0.40)
       faraday (~> 0.9)
@@ -51,5 +73,6 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
+  scraped_page_archive!
   scraperwiki!
   wikidata-client (~> 0.0.7)

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,8 +5,9 @@ require 'scraperwiki'
 require 'nokogiri'
 require 'colorize'
 require 'pry'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 class String
   def tidy

--- a/scraper.rb
+++ b/scraper.rb
@@ -34,11 +34,11 @@ end
 def scrape_mp(term, sortname, url)
   noko = noko_for(url)
 
-  data = { 
+  data = {
     id: url.to_s[/id=(\d+)$/, 1],
     # name: noko.css('.pagetitle span').first.text,
     name: noko.xpath('//title').text.split(' - ').last,
-    sortname: sortname, 
+    sortname: sortname,
     image: noko.css('.ArticleText2 img/@src').text,
     birth_date: dob_from(noko.css('.ArticleText2')),
     faction: noko.xpath('//td[b[contains(.,"Deputy club:")]]//a').text,
@@ -71,4 +71,3 @@ scrape_list(7, 'http://www.sabor.hr/0041') # left mid-way
 
 # scrape_list(6, 'http://www.sabor.hr/Default.aspx?sec=4897')
 # scrape_list(5, 'http://www.sabor.hr/Default.aspx?sec=2487')
-


### PR DESCRIPTION
This PR adds the scraped page archiver to the scraper while we wait for all the scraped page to be populated with links
## Scraped page archive
- [x] Until the [scraped page archiver issue is solved](https://github.com/everypolitician/scraped_page_archive/issues/37), use the https link for the repo's origin
- [x] Scraper uses scraped archive gem if upstream source has no archive itself
- [x] all gemfile links are secure (e.g., use https)
- [x] morph is configured to write to GitHub ("secret" environment vars)
- [x] pages are archived in new branch of correct scraper repo (yay!)
