### PR TITLE
Update scraper to changes made this week

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby '2.0.0'
 
-gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby.git', branch: 'morph_defaults'
+gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby', branch: 'morph_defaults'
 gem 'execjs'
 gem 'pry'
 gem 'colorize'

--- a/Gemfile
+++ b/Gemfile
@@ -2,17 +2,17 @@
 # specified here will be installed and made available to your morph.io scraper.
 # Find out more: https://morph.io/documentation/ruby
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby "2.0.0"
+ruby '2.0.0'
 
-gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
-gem "execjs"
-gem "pry"
-gem "colorize"
-gem "nokogiri"
-gem "open-uri-cached"
-gem "fuzzy_match"
+gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby.git', branch: 'morph_defaults'
+gem 'execjs'
+gem 'pry'
+gem 'colorize'
+gem 'nokogiri'
+gem 'open-uri-cached'
+gem 'fuzzy_match'
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
 gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/everypolitician/scraped_page_archive.git
-  revision: 317f10cf3c6abbfb7f1871e80c73b8d8cf07f07a
+  revision: 28f93d74b1c11ef01463ad0e7f874050d2e7fc73
   specs:
-    scraped_page_archive (0.4.1)
+    scraped_page_archive (0.5.0)
       git (~> 1.3.0)
       vcr-archive (~> 0.3.0)
 
@@ -18,36 +18,38 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
-    coderay (1.1.0)
-    colorize (0.7.7)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    coderay (1.1.1)
+    colorize (0.8.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    excon (0.45.4)
-    execjs (2.5.2)
-    faraday (0.9.1)
+    excon (0.54.0)
+    execjs (2.7.0)
+    faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
     fuzzy_match (2.1.0)
     git (1.3.0)
     hashdiff (0.3.0)
-    hashie (3.4.2)
-    httpclient (2.6.0.1)
+    hashie (3.4.6)
+    httpclient (2.8.2.4)
     method_source (0.8.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.1.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     open-uri-cached (0.0.5)
-    pry (0.10.1)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (2.0.4)
     safe_yaml (1.0.4)
     slop (3.6.0)
-    sqlite3 (1.3.10)
-    sqlite_magic (0.0.3)
+    sqlite3 (1.3.12)
+    sqlite_magic (0.0.6)
       sqlite3
     vcr (3.0.3)
     vcr-archive (0.3.0)
@@ -57,7 +59,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    wikidata-client (0.0.7)
+    wikidata-client (0.0.10)
       excon (~> 0.40)
       faraday (~> 0.9)
       faraday_middleware (~> 0.9)
@@ -76,3 +78,9 @@ DEPENDENCIES
   scraped_page_archive!
   scraperwiki!
   wikidata-client (~> 0.0.7)
+
+RUBY VERSION
+   ruby 2.0.0p648
+
+BUNDLED WITH
+   1.13.2


### PR DESCRIPTION
In the process of tidying up before I leave the team, I'm updating the Croatian scraper which doesn't include the changes introduced this week.

**Status of this country:** There have been new elections. [A PR is in place for this country to import the data for the new term](https://github.com/everypolitician/everypolitician-data/pull/19101), but we are waiting for the site to finish adding all the new members.

# Checklists

Country checklist: https://github.com/everypolitician/country-checklists/blob/master/croatia-sabor.md

## Sanity check

* [x] election has happened and new term is not in EveryPolitician already <https://en.wikipedia.org/wiki/Croatian_parliamentary_election,_2016>
* [x] you're looking at the *correct* house for *correct* country <https://en.wikipedia.org/wiki/Croatian_Parliament> == Sabor
* [x] there's not a much more urgent legislature you could be doing, is there? Nope


## Gemfile checklist

[See dedicated wiki page for explanations](https://github.com/everypolitician/everypolitician/wiki/Gemfile-checklist)

* [x] all links are secure
* [x] links to Github use `github:` protocol, not simply `git:`
* [x] file passes Rubocop with our normal setup (in particular, single quotes rather than double)


## Scraper Change checklist

[See dedicated wiki page for explanations](https://github.com/everypolitician/everypolitician/wiki/Scraper-Change-checklist)

* [x] scraper is on Morph.io under the "everypolitician-scrapers" group <https://morph.io/everypolitician-scrapers/croatia-parliament>
* [x] scraper's GitHub "Website" link points at morph.io page <https://github.com/everypolitician-scrapers/croatia-parliament>
* [x] scraper is set to auto-run <https://morph.io/everypolitician-scrapers/croatia-parliament/settings>
* [ ] ~legislature has a scraper webhook set _(usually only set on Wikidata person-data scrapers)_~ Not needed
* [x] scraper is configured for archiving _(unless source doesn't require that)_


## Archiving

[See dedicated wiki page for explanations](https://github.com/everypolitician/everypolitician/wiki/Adding-Archiving-to-Scraper-checklist)

* [x] we are using at least version 0.5 of scraped-page-archive-gem
* [x] scraper uses scraped-page-archive gem directly or via a suitable strategy
* [x] MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured <https://morph.io/everypolitician-scrapers/croatia-parliament/settings>
* [x] pages are being archived in new branch of correct scraper repo <https://github.com/everypolitician-scrapers/croatia-parliament/commits/scraped-pages-archive>

