### PR TITLE
WIP -- Use latest version of scraped_page_archive

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/everypolitician/scraped_page_archive.git
-  revision: 317f10cf3c6abbfb7f1871e80c73b8d8cf07f07a
+  revision: 28f93d74b1c11ef01463ad0e7f874050d2e7fc73
   specs:
-    scraped_page_archive (0.4.1)
+    scraped_page_archive (0.5.0)
       git (~> 1.3.0)
       vcr-archive (~> 0.3.0)
 
@@ -18,36 +18,38 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
-    coderay (1.1.0)
-    colorize (0.7.7)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    coderay (1.1.1)
+    colorize (0.8.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    excon (0.45.4)
-    execjs (2.5.2)
-    faraday (0.9.1)
+    excon (0.54.0)
+    execjs (2.7.0)
+    faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
     fuzzy_match (2.1.0)
     git (1.3.0)
     hashdiff (0.3.0)
-    hashie (3.4.2)
-    httpclient (2.6.0.1)
+    hashie (3.4.6)
+    httpclient (2.8.2.4)
     method_source (0.8.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.1.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     open-uri-cached (0.0.5)
-    pry (0.10.1)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (2.0.4)
     safe_yaml (1.0.4)
     slop (3.6.0)
-    sqlite3 (1.3.10)
-    sqlite_magic (0.0.3)
+    sqlite3 (1.3.12)
+    sqlite_magic (0.0.6)
       sqlite3
     vcr (3.0.3)
     vcr-archive (0.3.0)
@@ -57,7 +59,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    wikidata-client (0.0.7)
+    wikidata-client (0.0.10)
       excon (~> 0.40)
       faraday (~> 0.9)
       faraday_middleware (~> 0.9)
@@ -76,3 +78,9 @@ DEPENDENCIES
   scraped_page_archive!
   scraperwiki!
   wikidata-client (~> 0.0.7)
+
+RUBY VERSION
+   ruby 2.0.0p648
+
+BUNDLED WITH
+   1.13.5


### PR DESCRIPTION
Updated Gemfile.lock using `bundle update scraped_page_archive` so that we use the latest version of this gem.

Needed as scraper was failing on morph. This is a step towards fixing: https://github.com/everypolitician/everypolitician-data/pull/20975

@tmtmtmtm Could you run the scraper when this has been merged? Thanks.