### PR TITLE
Croatia Parliament -- Scrape all members

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,6 @@ gem 'nokogiri'
 gem 'open-uri-cached'
 gem 'pry'
 gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'
-gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby.git',
+gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
                    branch: 'morph_defaults'
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby '2.0.0'
+ruby '2.3.1'
 
 gem 'colorize'
 gem 'execjs'

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'fuzzy_match'
 gem 'nokogiri'
 gem 'open-uri-cached'
 gem 'pry'
+gem 'scraped', github: 'everypolitician/scraped'
 gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'
 gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
                    branch: 'morph_defaults'

--- a/Gemfile
+++ b/Gemfile
@@ -2,17 +2,18 @@
 # specified here will be installed and made available to your morph.io scraper.
 # Find out more: https://morph.io/documentation/ruby
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
-ruby "2.0.0"
+ruby '2.0.0'
 
-gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
-gem "execjs"
-gem "pry"
-gem "colorize"
-gem "nokogiri"
-gem "open-uri-cached"
-gem "fuzzy_match"
-gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
+gem 'colorize'
+gem 'execjs'
+gem 'fuzzy_match'
+gem 'nokogiri'
+gem 'open-uri-cached'
+gem 'pry'
 gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'
+gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby.git',
+                   branch: 'morph_defaults'
+gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/everypolitician/scraped.git
+  revision: aabdf259f6cc2f746b50352e078a9141450e8d6e
+  specs:
+    scraped (0.1.0)
+      field_serializer
+      nokogiri
+      require_all
+
+GIT
   remote: https://github.com/everypolitician/scraped_page_archive.git
   revision: 28f93d74b1c11ef01463ad0e7f874050d2e7fc73
   specs:
@@ -30,6 +39,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
+    field_serializer (0.2.0)
     fuzzy_match (2.1.0)
     git (1.3.0)
     hashdiff (0.3.0)
@@ -46,6 +56,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (2.0.4)
+    require_all (1.3.3)
     safe_yaml (1.0.4)
     slop (3.6.0)
     sqlite3 (1.3.10)
@@ -75,12 +86,13 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
+  scraped!
   scraped_page_archive!
   scraperwiki!
   wikidata-client (~> 0.0.7)
 
 RUBY VERSION
-   ruby 2.0.0p648
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.13.6

--- a/lib/decorators/absolute_links.rb
+++ b/lib/decorators/absolute_links.rb
@@ -1,0 +1,11 @@
+require 'scraped'
+
+class AbsoluteLinks < Scraped::Response::Decorator
+  def body
+    doc = Nokogiri::HTML(super)
+    doc.css('a').each do |link|
+      link[:href] = URI.join(url, URI.encode(link[:href])).to_s unless link[:href].nil?
+    end
+    doc.to_s
+  end
+end

--- a/lib/member_item.rb
+++ b/lib/member_item.rb
@@ -1,0 +1,21 @@
+require 'scraped'
+
+class MemberItem < Scraped::HTML
+  field :name do
+    split_row_text[0].split(',').reverse.join(' ').tidy
+  end
+
+  field :party do
+    split_row_text[1].tidy
+  end
+
+  field :sort_name do
+    split_row_text[0]
+  end
+  
+  private
+
+  def split_row_text
+    noko.xpath('text()').text.split("\r")
+  end
+end

--- a/lib/member_item.rb
+++ b/lib/member_item.rb
@@ -12,6 +12,10 @@ class MemberItem < Scraped::HTML
   field :sort_name do
     split_row_text[0]
   end
+
+  field :source do
+    url
+  end
   
   private
 

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -1,0 +1,55 @@
+require 'scraped'
+
+class MemberPage < Scraped::HTML
+  field :id do
+    url.to_s[/id=(\d+)$/, 1]
+  end
+
+  field :name do
+    noko.xpath('//title').text.split(' - ').last
+  end
+
+  field :image do
+    noko.css('.ArticleText2 img/@src').text
+  end
+
+  field :birth_date do
+    dob_from(noko.css('.ArticleText2'))
+  end
+
+  field :faction do
+    noko.xpath('//td[b[contains(.,"Deputy club:")]]//a').text
+  end
+
+  field :faction_id do
+    noko.xpath('//td[b[contains(.,"Deputy club:")]]//a/@href').text[/id=(\d+)/, 1]
+  end
+
+  field :party do
+    noko.css('td.Stranka').text.tidy
+  end
+
+  field :constituency do
+    noko.xpath('//td[b[contains(.,"Constituency:")]]/text()').text
+  end
+
+  field :start_date do
+    noko.xpath('//td[b[contains(.,"Begin of parliamentary mandate:")]]/text()').text.split('/').reverse.join('-')
+  end
+
+  field :end_date do
+    noko.xpath('//td[b[contains(.,"End of parliamentary mandate:")]]/text()').text.split('/').reverse.join('-')
+  end
+
+  field :source do
+    url.to_s
+  end
+
+  # TODO: Chamges, e.g. http://www.sabor.hr/Default.aspx?sec=5358
+
+  private
+
+  def dob_from(node)
+    Date.parse(node.text.tidy[/Born\s+(?:on)\s+(\d+\s+\w+\s+\d+)/, 1]).to_s rescue ''
+  end
+end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -1,9 +1,21 @@
 require 'scraped'
 
 class MembersPage < Scraped::HTML
-  field :members do
+  field :members_with_pages do
     noko.css('.liste2 .liste a').map do |a|
       MemberPage.new(response: Scraped::Request.new(url: a.attr('href')).response)
     end
+  end
+
+  field :members_without_pages do
+    noko.xpath('//td[@class= "liste"]').map do |row|
+      unless row.xpath('text()').text.split("\r")[0].empty?
+        MemberItem.new(response: response, noko: row)
+      end
+    end
+  end
+
+  field :members do
+    members_with_pages + members_without_pages
   end
 end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -1,0 +1,9 @@
+require 'scraped'
+
+class MembersPage < Scraped::HTML
+  field :members do
+    noko.css('.liste2 .liste a').map do |a|
+      MemberPage.new(response: Scraped::Request.new(url: a.attr('href')).response)
+    end
+  end
+end

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,9 +5,10 @@ require 'scraperwiki'
 require 'nokogiri'
 require 'colorize'
 require 'pry'
-# require 'open-uri/cached'
-# OpenURI::Cache.cache_path = '.cache'
-require 'scraped_page_archive/open-uri'
+require 'scraped'
+require 'require_all'
+
+require_rel 'lib'
 
 class String
   def tidy
@@ -19,45 +20,15 @@ def noko_for(url)
   Nokogiri::HTML(open(url).read)
 end
 
-def dob_from(node)
-  Date.parse(node.text.tidy[/Born\s+(?:on)\s+(\d+\s+\w+\s+\d+)/, 1]).to_s rescue ''
-end
-
 def scrape_list(term, url)
-  noko = noko_for(url)
-  noko.css('.liste2 .liste a').each do |a|
-    link = URI.join url, a.attr('href')
-    scrape_mp(term, a.text, link)
+  members_page = MembersPage.new(response: Scraped::Request.new(url: url).response(decorators: [AbsoluteLinks]))
+                    .members
+                    .map do |member_page|
+           member_page.to_h.merge(term: term)
+         end
+                    .each do |member_data|
+    ScraperWiki.save_sqlite([:id, :term], member_data)
   end
-end
-
-def scrape_mp(term, sortname, url)
-  noko = noko_for(url)
-
-  data = {
-    id: url.to_s[/id=(\d+)$/, 1],
-    # name: noko.css('.pagetitle span').first.text,
-    name: noko.xpath('//title').text.split(' - ').last,
-    sortname: sortname,
-    image: noko.css('.ArticleText2 img/@src').text,
-    birth_date: dob_from(noko.css('.ArticleText2')),
-    faction: noko.xpath('//td[b[contains(.,"Deputy club:")]]//a').text,
-    faction_id: noko.xpath('//td[b[contains(.,"Deputy club:")]]//a/@href').text[/id=(\d+)/, 1],
-    party: noko.css('td.Stranka').text.tidy,
-    constituency: noko.xpath('//td[b[contains(.,"Constituency:")]]/text()').text,
-    start_date: noko.xpath('//td[b[contains(.,"Begin of parliamentary mandate:")]]/text()').text.split('/').reverse.join('-'),
-    end_date: noko.xpath('//td[b[contains(.,"End of parliamentary mandate:")]]/text()').text.split('/').reverse.join('-'),
-    # TODO: Chamges, e.g. http://www.sabor.hr/Default.aspx?sec=5358
-    term: term,
-    source: url.to_s,
-  }
-  data[:image] = URI.join(url, data[:image]).to_s unless data[:image].to_s.empty?
-
-  if data[:faction].to_s.empty?
-    data[:faction] = "Independent"
-    warn "No faction in #{data[:source]}: setting to #{data[:faction]}".red
-  end
-  ScraperWiki.save_sqlite([:id, :term], data)
 end
 
 scrape_list(9, 'http://www.sabor.hr/Default.aspx?sec=4608')

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,6 +5,7 @@ require 'scraperwiki'
 require 'nokogiri'
 require 'colorize'
 require 'pry'
+require 'scraped_page_archive/open-uri'
 require 'scraped'
 require 'require_all'
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -27,7 +27,7 @@ def scrape_list(term, url)
            member_page.to_h.merge(term: term)
          end
                     .each do |member_data|
-    ScraperWiki.save_sqlite([:id, :term], member_data)
+    ScraperWiki.save_sqlite([:name, :term], member_data)
   end
 end
 


### PR DESCRIPTION
We do not currently have all members in our data.

Some members have not been scraped because the scraper only scraped members that had individual member pages. This PR amends the scraper so that members without pages are included in the scraped data.

The scraper was refactored for Scraped to facilitate the change.

Closes https://github.com/everypolitician/everypolitician-data/issues/21090

## [Scraper Change checklist](https://github.com/everypolitician/everypolitician/wiki/Scraper-Change-checklist)
* [x] 1. scraper is on Morph.io under the "everypolitician-scrapers" group? (The scraper has been moved. https://morph.io/tmtmtmtm/croatia-parliament/ will need to be deleted.)
* [x] 2. scraper's GitHub "Website" link points at morph.io page?
* [x] 3. scraper is set to auto-run?
* [x] 4. scraper is archiving?
* [x] 5. legislature has a scraper webhook set? (The legislature has a Wikidata scraper but I am not able to check its settings as it is under @tmtmtmtm's account.)