### PR TITLE
Add test framework

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 require 'rubocop/rake_task'
+require 'rake/testtask'
 
 RuboCop::RakeTask.new
 
-task default: %w(rubocop)
+Rake::TestTask.new do |t|
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+task default: %w(test rubocop)

--- a/test/dummy_test.rb
+++ b/test/dummy_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative './test_helper'
+
+describe 'dummy test' do
+  it 'should run' do
+    # This test is included to ensure that
+    # test_helper is run by Travis
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require 'minitest/around/spec'
+require 'minitest/autorun'
+require 'pry'
+require 'vcr'
+require 'webmock'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'test/cassettes'
+  c.hook_into :webmock
+end


### PR DESCRIPTION
Sets up repo so tests can be run.

Includes a dummy test to ensure Travis checks `test_helper`. Travis would not otherwise run `test_helper` as no other file requires it.

Part of: https://github.com/everypolitician/everypolitician-data/issues/26548