### PR TITLE
Set up for custom tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
+require 'rake/testtask'
 require 'rubocop/rake_task'
+require 'scraper_test'
 RuboCop::RakeTask.new
 
-require 'scraper_test'
 ScraperTest::RakeTask.new.install_tasks
+
+Rake::TestTask.new do |t|
+  t.test_files = FileList['test/**/*_test.rb']
+end
 
 task default: %w(rubocop test)

--- a/test/dummy_test.rb
+++ b/test/dummy_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative './test_helper'
+
+describe 'dummy test' do
+  it 'should run' do
+    # This test is included to ensure that
+    # test_helper is run by Travis
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require 'minitest/around/spec'
+require 'minitest/autorun'
+require 'pry'
+require 'vcr'
+require 'webmock'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'tests/cassettes'
+  c.hook_into :webmock
+end


### PR DESCRIPTION
This PR configures Rake to run tests in the test directory.

In a forthcoming commit, I will test individual `MemberRows` returned by `MembersPage`. To do that, I will want to test only part of the `MembersPage` data. I will do that by writing a custom test.

Part of: https://github.com/everypolitician/everypolitician-data/issues/26548