### PR TITLE
Store VCR cassettes in the test directory

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,6 @@ require 'vcr'
 require 'webmock'
 
 VCR.configure do |c|
-  c.cassette_library_dir = 'tests/cassettes'
+  c.cassette_library_dir = 'test/cassettes'
   c.hook_into :webmock
 end


### PR DESCRIPTION
VCR was configured to store tests in `tests/` instead of `test/`. This commit points the VCR configuration in `test_helper.rb` to the same directory in which the tests are stored so that we don't end up with more directories than we need.