### PR TITLE
Add scraper_test task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,5 @@ Rake::TestTask.new do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
 
+task test: 'test:data'
 task default: %w[rubocop test]


### PR DESCRIPTION
A test file exits in `tests\data` but it is not being run as there is no Rake task for scraper_test

This PR ensures that Rake runs the test.